### PR TITLE
Allow parallel deferments

### DIFF
--- a/src/defer.ts
+++ b/src/defer.ts
@@ -1,18 +1,33 @@
 export default class Deferred<T> {
+  public static resetNextId() {
+    Deferred._nextId = 0;
+  }
+
+  private static _nextId: number = 0;
+
+  private static getNextId() {
+    return Deferred._nextId++;
+  }
 
   private _promise: Promise<T>;
   private _resolve: (value?: T | PromiseLike<T>) => void;
   private _reject: (reason?: any) => void;
+  private _id: number;
 
   constructor() {
     this._promise = new Promise<T>((resolve, reject) => {
       this._resolve = resolve;
       this._reject = reject;
     });
+    this._id = Deferred.getNextId();
   }
 
   public get promise(): Promise<T> {
     return this._promise;
+  }
+
+  public get id(): number {
+    return this._id;
   }
 
   public resolve = (value?: T | PromiseLike<T>): void => {
@@ -22,5 +37,4 @@ export default class Deferred<T> {
   public reject = (reason?: any): void => {
     this._reject(reason);
   }
-
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -253,7 +253,7 @@ export default class Copper {
   }
 
   private _postMessage(type: string, message: { [name: string]: any } = {}): void {
-    this.win.top.postMessage(
+    this.win.top?.postMessage(
       {
         // actual messages
         ...message,

--- a/test/defer.spec.ts
+++ b/test/defer.spec.ts
@@ -25,4 +25,22 @@ describe('defer', function () {
     });
     deferred.reject({ error: 'Bob' });
   });
+
+  it('should contain auto-incremented id', function () {
+    Deferred.resetNextId();
+
+    const deferred1 = new Deferred<string>();
+    expect(deferred1.id).to.equal(0);
+
+    const deferred2 = new Deferred<string>();
+    expect(deferred2.id).to.equal(1);
+
+    const x = 5;
+    let deferredX;
+    for (let i = 0; i < x; i++) {
+      deferredX = new Deferred<string>();
+    }
+
+    expect(deferredX?.id).to.equal(1 + x);
+  });
 });


### PR DESCRIPTION
The deferred apis were pushing into an array, and then unshifting on the other side of the async operation. This caused api calls to desync.

e.g. you request
```js
a = sdk('endpointA')
b = sdk('endpointB')
```

if async operation completes B faster than A, then `a` would incorrectly have the result of endpointB and vice versa.

This PR switches to an id system so that the correct deferment can be looked up on the other side of the async operation.